### PR TITLE
Bug/handle unexported fields

### DIFF
--- a/log_test.go
+++ b/log_test.go
@@ -39,6 +39,11 @@ type EventWithNestedEmbeddedStructs struct {
 	Nested  EventWithEmbeddedStructs `logevent:"nested"`
 }
 
+type EventWithUnexportedField struct {
+	Message    string `logevent:"message,default=testvalue"`
+	unexported string `logevent:"unexported,default=fizz"`
+}
+
 type tagTestCase struct {
 	Level zerolog.Level
 	Func  func(eventMessage, Logger)
@@ -219,4 +224,35 @@ func TestLoggerTagsWithNestedEmbeddedStructs(t *testing.T) {
 	require.Equal(t, "testvalue", nestedStruct["message"])
 	require.Equal(t, "fizz", nestedStruct["one"])
 	require.Equal(t, timeField.Format(time.RFC3339Nano), nestedStruct["two"])
+}
+
+func TestLoggerTagsWithUnexportedField(t *testing.T) {
+	var eventWithUnexported = EventWithUnexportedField{
+		Message:    "testmessage",
+		unexported: "unexported",
+	}
+
+	var buff = &bytes.Buffer{}
+	var c = Config{Output: buff}
+	var logger = New(c)
+
+	logger.Error(eventWithUnexported)
+
+	var lines = strings.Split(strings.Trim(buff.String(), "\n"), "\n")
+	var line = make(map[string]interface{})
+	_ = json.Unmarshal([]byte(lines[0]), &line)
+	var _, okFile = line["file"]
+	var _, okTime = line["time"]
+	require.True(t, okFile, "log line missing file attribute")
+	require.True(t, okTime, "log line missing time attribute")
+	require.Equal(t, "error", line["level"])
+	require.Equal(t, "testmessage", line["message"])
+
+	var _, okExported = line["message"]
+	require.True(t, okExported, "log line missing nested attribute")
+
+	// unexported fields should be silently omitted from the log
+	var _, okUnexported = line["unexported"]
+	require.False(t, okUnexported, "log line has nested attribute")
+
 }


### PR DESCRIPTION
IMO, no log library should ever cause a panic.  The problem is that if someone (lazily) codes `logger.Error(err)` where `err` is a `go` `Error` type, it has unexported fields that cause a panic where `render.go` calls https://github.com/fatih/structs/blob/master/field.go#L28-L32, which you can see explicitly documents that it will panic.

If the `logger.Error` func call is in a code path uncovered by unit/function/integration test, it's a panic waiting to happen at runtime.  Even if it _is_ covered by unit/function/integration test, it's likely the logger is a mock and not exhibiting the runtime panic.  We don't want runtime panics!  Rather than panicking at runtime, this PR changes behavior such that the logger prints all _exported_ fields and gracefully ignores _unexported_ fields.

It does this by processing all fields each in an independent go routine that can catch and recover from panics (see `render.go`).  Reason for go routines per struct field is so that the annotations can still be applied to exported struct fields; we can't do the panic recover higher up, else we would fail to annotate exported fields.