### PR TITLE
Added transaction id functions to logevent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@
 <!-- TOC -->
 
 - [logevent - A structured event logger abstraction](#logevent---a-structured-event-logger-abstraction)
-    - [Usage](#usage)
-        - [Defining Events](#defining-events)
-        - [Logging Events](#logging-events)
-        - [Adding Adapters](#adding-adapters)
-    - [Contributing](#contributing)
-        - [License](#license)
-        - [Contributing Agreement](#contributing-agreement)
+  - [Usage](#usage)
+    - [Defining Events](#defining-events)
+    - [Logging Events](#logging-events)
+    - [Transaction IDs](#transaction-ids)
+    - [Adding Adapters](#adding-adapters)
+  - [Contributing](#contributing)
+    - [License](#license)
+    - [Contributing Agreement](#contributing-agreement)
 
 <!-- /TOC -->
 
@@ -51,6 +52,25 @@ logevent.FromContext(ctx).Info(myEvent{}) // Log the event
 logevent.FromContext(ctx).SetField("key", "value")
 logevent.FromContext(ctx).Warn("uh oh") // Fall back to string logging if not an event.
 var newCtx = logevent.NewContext(context.Background(), logger.Copy())
+```
+
+<a id="markdown-transaction-ids" name="transaction-ids"></a>
+### Transaction IDs
+
+You can add a `transaction_id` field to your logs by following the example below.
+Once a transaction id is set, all future logs written will automatically contain the transaction id.
+This is incredibly usefulfor tracing requests through a microservice and/or across multiple microservices.
+Note: if the `transactionID` parameter is left empty, a uuid will be randomly generated for you.
+```golang
+logger := logevent.New(logevent.Config{Level: "INFO"})
+ctx := logevent.NewContext(context.Background(), logger)
+logevent.SetTransactionID(ctx, &logger, "1234")
+```
+
+
+To retrieve a previously set transaction id, follow this example:
+```golang
+txid := logevent.GetTransactionID(ctx)
 ```
 
 <a id="markdown-adding-adapters" name="adding-adapters"></a>

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/fatih/structs v1.1.0
 	github.com/golang/mock v1.6.0
+	github.com/google/uuid v1.2.0
 	github.com/rs/xhandler v0.0.0-20170707052532-1eb70cf1520d // indirect
 	github.com/rs/xlog v0.0.0-20171227185259-131980fab91b
 	github.com/rs/zerolog v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -5,7 +5,10 @@ github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -20,6 +23,7 @@ github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThC
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
@@ -30,6 +34,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJV
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -50,4 +55,5 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/transaction.go
+++ b/transaction.go
@@ -1,0 +1,40 @@
+package logevent
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+const (
+	// TransactionIDKey is the key name being set in the logger
+	TransactionIDKey = "transaction_id"
+
+	transactionIDContextKey = ctxKey("__logevent_transaction_id")
+)
+
+// SetTransactionID sets a transaction id string in the logger and context.
+// If an empty string is passed in, then a randomly generated uuid will be used as the transaction id.
+func SetTransactionID(ctx context.Context, logger *Logger, transactionID string) context.Context {
+
+	if transactionID == "" {
+
+		var ok bool
+		transactionID, ok = ctx.Value(transactionIDContextKey).(string)
+		if !ok {
+			transactionID = uuid.New().String()
+		}
+
+	}
+
+	(*logger).SetField(TransactionIDKey, transactionID)
+
+	return context.WithValue(ctx, transactionIDContextKey, transactionID)
+}
+
+// GetTransactionID retrieves the transaction id after `SetTransactionID` has been called.
+// It will return an empty string if no transaction id has been set.
+func GetTransactionID(ctx context.Context) string {
+	transactionID, _ := ctx.Value(transactionIDContextKey).(string)
+	return transactionID
+}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -1,0 +1,60 @@
+package logevent
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetAndGetTransactionID(t *testing.T) {
+
+	var cases = []struct {
+		name         string
+		mocks        func(ctx context.Context)
+		ctx          context.Context
+		logger       Logger
+		txid         string
+		expectedTxid string
+	}{
+		{
+			name:         "Empty txid",
+			ctx:          context.Background(),
+			txid:         "",
+			expectedTxid: "",
+		},
+		{
+			name:         "Txid in context",
+			ctx:          context.WithValue(context.Background(), transactionIDContextKey, "1234"),
+			txid:         "",
+			expectedTxid: "1234",
+		},
+		{
+			name:         "Txid passed in",
+			ctx:          context.Background(),
+			txid:         "abcd",
+			expectedTxid: "abcd",
+		},
+	}
+
+	for _, currentCase := range cases {
+		t.Run(currentCase.name, func(tb *testing.T) {
+
+			buf := &bytes.Buffer{}
+			currentCase.logger = New(Config{Output: buf})
+
+			ctx := SetTransactionID(currentCase.ctx, &currentCase.logger, currentCase.txid)
+			txid := GetTransactionID(ctx)
+
+			if currentCase.expectedTxid == "" {
+				assert.NotEmpty(t, txid)
+			} else {
+				assert.Equal(t, currentCase.expectedTxid, txid)
+			}
+
+			currentCase.logger.Info("Some log statement")
+			assert.Contains(t, buf.String(), txid)
+		})
+	}
+}


### PR DESCRIPTION
These functions allow for a transaction id field to be set in the logger so that all logs from a given service can be segmented by transaction.